### PR TITLE
changelog script

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix=''

--- a/bin/changelog
+++ b/bin/changelog
@@ -1,0 +1,65 @@
+#! /usr/bin/env node
+
+const { exec, execSync, spawnSync } = require('child_process')
+
+const todaysDate = execSync('date "+%Y-%m-%d"').toString().trim()
+const commitMessage = `chore(): Update(CHANGELOG.md) ${todaysDate}`
+const lastCommit = execSync('git rev-parse HEAD').toString().trim()
+const versionType = process.argv.slice(2)[0]
+const dryrun = process.argv.slice(2)[1] // Don't push to github if true
+
+if (!versionType) {
+  console.log('Please add a version type: "major", "minor", or "patch".')
+  return
+}
+
+let flag = ''
+switch(versionType) {
+  case 'major':
+    flag = '-M'
+    break
+  case 'minor':
+    flag = '-m'
+    break
+  case 'patch':
+    flag = '-p'
+    break
+  default:
+    console.log('Version type _%s_ is not valid. Try "major", "minor", or "patch".', versionType)
+    return
+}
+
+const envDefaults = Object.assign(process.env, { versionType: versionType,
+                                                  lastCommit: lastCommit,
+                                                  flag: flag,
+                                                  commitMessage: commitMessage })
+
+function execCommand(command, errCb) {
+  return new Promise((resolve, reject) => {
+    exec(command, { env: envDefaults }, (err, stdout, stderr) => {
+      if (err || stderr) {
+        console.log(`* * * ${command} command failed.`)
+        if (err) {
+          console.log(`* * * err: `, err)
+        } else {
+          console.log(`* * * stderr: `, stderr)
+        }
+        if ('function' == typeof errCb) {
+          errCb()
+          return
+        }
+        return
+      }
+      resolve(stdout)
+    })
+  })
+}
+
+async function updateChangelog() {
+  await execCommand(`changelog "$flag"`)
+  await execCommand(`git add CHANGELOG.md && git commit -m "$commitMessage"`)
+  await execCommand(`npm version "$versionType"`, exec(`git reset --hard "$lastCommit"`))
+  if ( Boolean(!dryrun) ) { await execCommand(`git push origin master --tags`) }
+}
+
+updateChangelog()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "lintfix": "eslint . --fix",
     "coverage": "npm run nyc",
-    "nyc": "nyc npm test"
+    "nyc": "nyc npm test",
+    "release-version": "bin/changelog"
   },
   "repository": {
     "type": "git",
@@ -32,6 +33,8 @@
     "ava": "^0.25.0",
     "eslint": "^4.19.1",
     "eslint-config-ara": "github:arablocks/eslint-config-ara",
-    "eslint-plugin-import": "^2.12.0"
+    "eslint-plugin-import": "^2.12.0",
+    "generate-changelog": "^1.7.1",
+    "jsdoc-to-markdown": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ara-reponame",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "description": "Description of ara-reponame.",
   "main": "index.js",
   "bin": {},
@@ -10,7 +10,7 @@
     "lintfix": "eslint . --fix",
     "coverage": "npm run nyc",
     "nyc": "nyc npm test",
-    "release-version": "bin/changelog"
+    "release-version": "./scripts/changelog"
   },
   "repository": {
     "type": "git",

--- a/scripts/changelog
+++ b/scripts/changelog
@@ -1,4 +1,4 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 const { exec, execSync, spawnSync } = require('child_process')
 
@@ -6,7 +6,7 @@ const todaysDate = execSync('date "+%Y-%m-%d"').toString().trim()
 const commitMessage = `chore(): Update(CHANGELOG.md) ${todaysDate}`
 const lastCommit = execSync('git rev-parse HEAD').toString().trim()
 const versionType = process.argv.slice(2)[0]
-const dryrun = process.argv.slice(2)[1] // Don't push to github if true
+const dryRun = process.argv.slice(2)[1] // Don't push to github if true
 
 if (!versionType) {
   console.log('Please add a version type: "major", "minor", or "patch".')
@@ -29,10 +29,10 @@ switch(versionType) {
     return
 }
 
-const envDefaults = Object.assign(process.env, { versionType: versionType,
-                                                  lastCommit: lastCommit,
-                                                  flag: flag,
-                                                  commitMessage: commitMessage })
+const envDefaults = Object.assign(process.env, { versionType,
+                                                 lastCommit,
+                                                 flag,
+                                                 commitMessage })
 
 function execCommand(command, errCb) {
   return new Promise((resolve, reject) => {
@@ -59,7 +59,7 @@ async function updateChangelog() {
   await execCommand(`changelog "$flag"`)
   await execCommand(`git add CHANGELOG.md && git commit -m "$commitMessage"`)
   await execCommand(`npm version "$versionType"`, exec(`git reset --hard "$lastCommit"`))
-  if ( Boolean(!dryrun) ) { await execCommand(`git push origin master --tags`) }
+  if ( Boolean(!dryRun )) { await execCommand(`git push origin master --tags`) }
 }
 
 updateChangelog()


### PR DESCRIPTION
Fixes #3 

## Proposed Changes

  - A little more robust npm version bump script
  - Add .npmrc to remove `v` prefix from tag names
  - Generate a changelog with version bumps

- TODO: test this more vigorously.