### PR TITLE
Fix subcommand sort

### DIFF
--- a/scripts/shipright
+++ b/scripts/shipright
@@ -444,7 +444,7 @@ module.exports = (async function main() {
     fs.mkdirSync(argv.output)
   }
 
-  parentCommand = files.sort((a, b) => a.length > b.length)[0]
+  parentCommand = files.sort((a, b) => a.length - b.length)[0]
 
   console.log(`Setting \`${parentCommand}\` as 'parent command'`)
 


### PR DESCRIPTION
## Proposed Changes

  - Sort used `<` instead of `-`, resulting in an inaccurate sort to find the parent command for CLI doc generation